### PR TITLE
Fix issue when screenshot directory is deleted before the test ends

### DIFF
--- a/tests/challenging_dom.spec.js
+++ b/tests/challenging_dom.spec.js
@@ -54,9 +54,7 @@ test.describe("Challengin DOM page tests", () => {
 
         expect(resBefore).not.toEqual(resAfter); // checking that the canvas has changed after the button click
       }
-    });
 
-    test.afterAll("Delete the screenshots", async () => {
       // deleting screenshots directory used for the canvas tests
       fs.rm("canvasScrs", { recursive: true, force: true }, (err) => {
         if (err) throw err;


### PR DESCRIPTION
Fixed an issue when screenshot directory was deleted before the test ends, resulting in failure. Removed the afterall hook and moved deletion functionality to the test body